### PR TITLE
Ranges support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,13 @@ edition = "2018"
 chrono = "0.4.10"
 futures-util = "0.3.1"
 http = "0.2.0"
+http-range = "0.1.4"
 hyper = { version = "0.14.0", features = ["stream"] }
 mime_guess = "2.0.1"
 percent-encoding = "2.1.0"
 tokio = { version = "1.0.0", features = ["fs"] }
 url = "2.1.0"
+rand = "0.8.4"
 
 [dev-dependencies]
 hyper = { version = "0.14.0", features = ["http1", "server", "tcp"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ http-range = "0.1.4"
 hyper = { version = "0.14.0", features = ["stream"] }
 mime_guess = "2.0.1"
 percent-encoding = "2.1.0"
+rand = "0.8.4"
 tokio = { version = "1.0.0", features = ["fs"] }
 url = "2.1.0"
-rand = "0.8.4"
 
 [dev-dependencies]
 hyper = { version = "0.14.0", features = ["http1", "server", "tcp"] }

--- a/src/response_builder.rs
+++ b/src/response_builder.rs
@@ -98,13 +98,7 @@ impl<'a> ResponseBuilder<'a> {
             }
             ResolveResult::Found(file, metadata, mime) => self
                 .file_response_builder
-                .build(file, metadata)
-                .map(|mut r| {
-                    let header_val =
-                        header::HeaderValue::from_str(&mime.to_string()).expect("Invalid mimetype");
-                    r.headers_mut().insert(header::CONTENT_TYPE, header_val);
-                    r
-                }),
+                .build(file, metadata, mime.to_string()),
         }
     }
 }

--- a/src/response_builder.rs
+++ b/src/response_builder.rs
@@ -96,9 +96,10 @@ impl<'a> ResponseBuilder<'a> {
                     .header(header::LOCATION, target)
                     .body(Body::empty())
             }
-            ResolveResult::Found(file, metadata, mime) => self
-                .file_response_builder
-                .build(file, metadata, mime.to_string()),
+            ResolveResult::Found(file, metadata, mime) => {
+                self.file_response_builder
+                    .build(file, metadata, mime.to_string())
+            }
         }
     }
 }

--- a/src/util/file_bytes_stream.rs
+++ b/src/util/file_bytes_stream.rs
@@ -1,12 +1,12 @@
 use futures_util::stream::Stream;
 use http_range::HttpRange;
 use hyper::body::{Body, Bytes};
+use std::cmp::min;
 use std::io::{Cursor, Error as IoError, SeekFrom, Write};
 use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::vec;
-use std::cmp::min;
 use tokio::fs::File;
 use tokio::io::{AsyncRead, AsyncSeek, ReadBuf};
 

--- a/src/util/file_bytes_stream.rs
+++ b/src/util/file_bytes_stream.rs
@@ -139,7 +139,8 @@ impl FileBytesStreamRange {
 
 /// Wraps a `tokio::fs::File`, and implements a stream of `Bytes`s reading multiple portions of
 /// the file given by `ranges` using a chunked multipart/byteranges response.  A boundary is
-/// required to separate the chunked components.
+/// required to separate the chunked components and therefore needs to be unlikely to be in any
+/// file.
 pub struct FileBytesStreamMultiRange {
     file_range: FileBytesStreamRange,
     range_iter: vec::IntoIter<HttpRange>,

--- a/src/util/file_bytes_stream.rs
+++ b/src/util/file_bytes_stream.rs
@@ -15,112 +15,20 @@ const BUF_SIZE: usize = 8 * 1024;
 pub struct FileBytesStream {
     file: File,
     buf: Box<[MaybeUninit<u8>; BUF_SIZE]>,
-    range_bytes: Option<RangeBytes>,
+    range_remaining: u64,
 }
 
-struct RangeBytes {
-    seek_completed: bool,
-    range_remaining: u64,
-    file_length: u64,
-    ranges: vec::IntoIter<HttpRange>,
-    // Only used if there is more than one range
-    boundary: String,
-    // Only used if there is more than one range
-    is_first_boundary: bool,
-}
 
 impl FileBytesStream {
     /// Create a new stream from the given file.
     pub fn new(file: File) -> FileBytesStream {
         let buf = Box::new([MaybeUninit::uninit(); BUF_SIZE]);
-        FileBytesStream { file, buf, range_bytes: None }
+        FileBytesStream { file, buf, range_remaining: u64::MAX }
     }
 
-    /// Set ranges if the client requested it.  Boundary must be the empty string if there is only one
-    /// range.  It is invalid to pass a list of zero ranges.
-    pub fn set_ranges(&mut self, ranges: Vec<HttpRange>, boundary: String, file_length: u64) -> &mut Self {
-        assert_eq!(ranges.len() > 1, boundary.len() > 0);
-        let is_first_boundary = ranges.len() > 1;
-        self.range_bytes = Some(RangeBytes {
-            seek_completed: true,
-            range_remaining: 0,
-            file_length,
-            ranges: ranges.into_iter(),
-            boundary,
-            is_first_boundary,
-        });
-        self
-    }
-}
-
-impl RangeBytes {
-
-    pub fn handle(&mut self, file: &mut File, buf: &mut [MaybeUninit<u8>], cx: &mut Context) -> Poll<Option<Result<Bytes, IoError>>> {
-        loop {
-            if !self.seek_completed {
-                match Pin::new(&mut *file).poll_complete(cx) {
-                    Poll::Ready(Ok(..)) => (),
-                    Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
-                    Poll::Pending => return Poll::Pending,
-                }
-            }
-
-            // we've finished the previous range (or we're just starting), we need to seek
-            // and repopulate the remaining field if we're not completely finished.
-            if self.range_remaining == 0 {
-                let range = match self.ranges.next() {
-                    Some(r) => r,
-                    None => return Poll::Ready(None),
-                };
-                if let Err(e) = Pin::new(&mut *file).start_seek(SeekFrom::Start(range.start)) {
-                    return Poll::Ready(Some(Err(e)));
-                }
-                self.seek_completed = false;
-                self.range_remaining = range.length;
-                if self.boundary.len() > 0 {
-                    let mut mp_header = Vec::new();
-                    if self.is_first_boundary {
-                        self.is_first_boundary = false;
-                    } else {
-                        write!(&mut mp_header, "\r\n").unwrap();
-                    }
-                    write!(&mut mp_header, "--{}\r\n", self.boundary).unwrap();
-                    write!(
-                        &mut mp_header,
-                        "Content-Range: bytes {}-{}/{}\r\n",
-                        range.start,
-                        range.start + range.length - 1,
-                        self.file_length,
-                    )
-                    .unwrap();
-                    // write!(&mut mp_header, "Content-Type: {}\r\n", file_mime_type).unwrap();
-                    write!(&mut mp_header, "\r\n").unwrap();
-
-                    return Poll::Ready(Some(Ok(mp_header.into())));
-                }
-
-                // back to the top of the loop so we can poll on the seek's completion
-            } else {
-                let rr = std::cmp::min(self.range_remaining, usize::max_value() as u64) as usize;
-                let max_read_length = std::cmp::min(rr, buf.len());
-
-                let mut read_buf = ReadBuf::uninit(&mut buf[..max_read_length]);
-                return match Pin::new(&mut *file).poll_read(cx, &mut read_buf) {
-                    Poll::Ready(Ok(())) => {
-                        let filled = read_buf.filled();
-                        self.range_remaining -= filled.len() as u64;
-                        if filled.is_empty() {
-                            Poll::Ready(None)
-                        } else {
-                            Poll::Ready(Some(Ok(Bytes::copy_from_slice(filled))))
-                        }
-                    }
-                    Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
-                    Poll::Pending => Poll::Pending,
-                }
-            }
-        }
-
+    fn new_with_limit(file: File, range_remaining: u64) -> FileBytesStream {
+        let buf = Box::new([MaybeUninit::uninit(); BUF_SIZE]);
+        FileBytesStream { file, buf, range_remaining }
     }
 }
 
@@ -131,30 +39,162 @@ impl Stream for FileBytesStream {
         let Self {
             ref mut file,
             ref mut buf,
-            ref mut range_bytes,
+            range_remaining,
         } = *self;
 
-        if let Some(rb) = range_bytes {
-            rb.handle(file, &mut buf[..], cx)
-        } else {
-            let mut read_buf = ReadBuf::uninit(&mut buf[..]);
-            match Pin::new(file).poll_read(cx, &mut read_buf) {
-                Poll::Ready(Ok(())) => {
-                    let filled = read_buf.filled();
-                    if filled.is_empty() {
-                        Poll::Ready(None)
-                    } else {
-                        Poll::Ready(Some(Ok(Bytes::copy_from_slice(filled))))
-                    }
+        let rr = std::cmp::min(range_remaining, usize::max_value() as u64) as usize;
+        let max_read_length = std::cmp::min(rr, buf.len());
+
+        let mut read_buf = ReadBuf::uninit(&mut buf[..max_read_length]);
+        match Pin::new(file).poll_read(cx, &mut read_buf) {
+            Poll::Ready(Ok(())) => {
+                let filled = read_buf.filled();
+                if filled.is_empty() {
+                    Poll::Ready(None)
+                } else {
+                    Poll::Ready(Some(Ok(Bytes::copy_from_slice(filled))))
                 }
-                Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
-                Poll::Pending => Poll::Pending,
             }
+            Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+            Poll::Pending => Poll::Pending,
         }
     }
 }
 
 impl FileBytesStream {
+    /// Create a Hyper `Body` from this stream.
+    pub fn into_body(self) -> Body {
+        Body::wrap_stream(self)
+    }
+}
+
+#[derive(PartialEq, Eq)]
+enum FileSeekState {
+    NeedSeek,
+    Seeking,
+    Reading,
+}
+
+pub struct FileBytesStreamRange {
+    file_stream: FileBytesStream,
+    seek_state: FileSeekState,
+    start_offset: u64,
+}
+
+impl FileBytesStreamRange {
+    pub fn new(file: File, range: HttpRange) -> FileBytesStreamRange {
+        FileBytesStreamRange {
+            file_stream: FileBytesStream::new_with_limit(file, range.length),
+            start_offset: range.start,
+            seek_state: FileSeekState::NeedSeek,
+            
+        }
+    }
+}
+
+impl Stream for FileBytesStreamRange {
+    type Item = Result<Bytes, IoError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        let Self {
+            ref mut file_stream,
+            ref mut seek_state,
+            start_offset,
+        } = *self;
+        if *seek_state == FileSeekState::NeedSeek {
+            *seek_state = FileSeekState::Seeking;
+            if let Err(e) = Pin::new(&mut file_stream.file).start_seek(SeekFrom::Start(start_offset)) {
+                return Poll::Ready(Some(Err(e)));
+            }
+        }
+        if *seek_state == FileSeekState::Seeking {
+            match Pin::new(&mut file_stream.file).poll_complete(cx) {
+                Poll::Ready(Ok(..)) => *seek_state = FileSeekState::Reading,
+                Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        Pin::new(file_stream).poll_next(cx)
+    }
+}
+
+
+impl FileBytesStreamRange {
+    /// Create a Hyper `Body` from this stream.
+    pub fn into_body(self) -> Body {
+        Body::wrap_stream(self)
+    }
+}
+
+pub struct FileBytesStreamMultiRange {
+    file_range: FileBytesStreamRange,
+    range_iter: vec::IntoIter<HttpRange>,
+    is_first_boundary: bool,
+    boundary: String,
+    file_length: u64,
+}
+
+impl FileBytesStreamMultiRange {
+    pub fn new(file: File, ranges: Vec<HttpRange>, boundary: String, file_length: u64) -> FileBytesStreamMultiRange {
+        let mut range_iter = ranges.into_iter();
+        let first_range = range_iter.next().expect("ranges must not be empty");
+        FileBytesStreamMultiRange {
+            file_range: FileBytesStreamRange::new(file, first_range),
+            range_iter,
+            boundary,
+            is_first_boundary: true,
+            file_length,
+        }
+    }
+}
+
+impl Stream for FileBytesStreamMultiRange {
+    type Item = Result<Bytes, IoError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        let Self {
+            ref mut file_range,
+            ref mut range_iter,
+            ref mut is_first_boundary,
+            ref boundary,
+            file_length,
+        } = *self;
+
+        if file_range.file_stream.range_remaining == 0 {
+            let range = match range_iter.next() {
+                Some(r) => r,
+                None => return Poll::Ready(None),
+            };
+            file_range.seek_state = FileSeekState::NeedSeek;
+            file_range.file_stream.range_remaining = range.length;
+            let mut mp_header = Vec::new();
+
+            if *is_first_boundary {
+                *is_first_boundary = false;
+            } else {
+                write!(&mut mp_header, "\r\n").unwrap();
+            }
+            write!(
+                &mut mp_header,
+                "--{}\r\nContent-Range: bytes {}-{}/{}\r\n\r\n",
+                boundary,
+                range.start,
+                range.start + range.length - 1,
+                file_length,
+            ).unwrap();
+
+            return Poll::Ready(Some(Ok(mp_header.into())));
+        }
+        
+        match Pin::new(file_range).poll_next(cx) {
+            Poll::Ready(None) => unreachable!(),
+            other => return other,
+        }
+    }
+}
+
+impl FileBytesStreamMultiRange {
     /// Create a Hyper `Body` from this stream.
     pub fn into_body(self) -> Body {
         Body::wrap_stream(self)

--- a/src/util/file_bytes_stream.rs
+++ b/src/util/file_bytes_stream.rs
@@ -1,11 +1,13 @@
 use futures_util::stream::Stream;
+use http_range::HttpRange;
 use hyper::body::{Body, Bytes};
-use std::io::Error as IoError;
+use std::io::{Error as IoError, Write, SeekFrom};
 use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::vec;
 use tokio::fs::File;
-use tokio::io::{AsyncRead, ReadBuf};
+use tokio::io::{AsyncRead, AsyncSeek, ReadBuf};
 
 const BUF_SIZE: usize = 8 * 1024;
 
@@ -13,13 +15,112 @@ const BUF_SIZE: usize = 8 * 1024;
 pub struct FileBytesStream {
     file: File,
     buf: Box<[MaybeUninit<u8>; BUF_SIZE]>,
+    range_bytes: Option<RangeBytes>,
+}
+
+struct RangeBytes {
+    seek_completed: bool,
+    range_remaining: u64,
+    file_length: u64,
+    ranges: vec::IntoIter<HttpRange>,
+    // Only used if there is more than one range
+    boundary: String,
+    // Only used if there is more than one range
+    is_first_boundary: bool,
 }
 
 impl FileBytesStream {
     /// Create a new stream from the given file.
     pub fn new(file: File) -> FileBytesStream {
         let buf = Box::new([MaybeUninit::uninit(); BUF_SIZE]);
-        FileBytesStream { file, buf }
+        FileBytesStream { file, buf, range_bytes: None }
+    }
+
+    /// Set ranges if the client requested it.  Boundary must be the empty string if there is only one
+    /// range.  It is invalid to pass a list of zero ranges.
+    pub fn set_ranges(&mut self, ranges: Vec<HttpRange>, boundary: String, file_length: u64) -> &mut Self {
+        assert_eq!(ranges.len() > 1, boundary.len() > 0);
+        let is_first_boundary = ranges.len() > 1;
+        self.range_bytes = Some(RangeBytes {
+            seek_completed: true,
+            range_remaining: 0,
+            file_length,
+            ranges: ranges.into_iter(),
+            boundary,
+            is_first_boundary,
+        });
+        self
+    }
+}
+
+impl RangeBytes {
+
+    pub fn handle(&mut self, file: &mut File, buf: &mut [MaybeUninit<u8>], cx: &mut Context) -> Poll<Option<Result<Bytes, IoError>>> {
+        loop {
+            if !self.seek_completed {
+                match Pin::new(&mut *file).poll_complete(cx) {
+                    Poll::Ready(Ok(..)) => (),
+                    Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
+                    Poll::Pending => return Poll::Pending,
+                }
+            }
+
+            // we've finished the previous range (or we're just starting), we need to seek
+            // and repopulate the remaining field if we're not completely finished.
+            if self.range_remaining == 0 {
+                let range = match self.ranges.next() {
+                    Some(r) => r,
+                    None => return Poll::Ready(None),
+                };
+                if let Err(e) = Pin::new(&mut *file).start_seek(SeekFrom::Start(range.start)) {
+                    return Poll::Ready(Some(Err(e)));
+                }
+                self.seek_completed = false;
+                self.range_remaining = range.length;
+                if self.boundary.len() > 0 {
+                    let mut mp_header = Vec::new();
+                    if self.is_first_boundary {
+                        self.is_first_boundary = false;
+                    } else {
+                        write!(&mut mp_header, "\r\n").unwrap();
+                    }
+                    write!(&mut mp_header, "--{}\r\n", self.boundary).unwrap();
+                    write!(
+                        &mut mp_header,
+                        "Content-Range: bytes {}-{}/{}\r\n",
+                        range.start,
+                        range.start + range.length - 1,
+                        self.file_length,
+                    )
+                    .unwrap();
+                    // write!(&mut mp_header, "Content-Type: {}\r\n", file_mime_type).unwrap();
+                    write!(&mut mp_header, "\r\n").unwrap();
+
+                    return Poll::Ready(Some(Ok(mp_header.into())));
+                }
+
+                // back to the top of the loop so we can poll on the seek's completion
+            } else {
+                let rr = std::cmp::min(self.range_remaining, usize::max_value() as u64) as usize;
+                let max_read_length = std::cmp::min(rr, buf.len());
+
+                let mut read_buf = ReadBuf::uninit(&mut buf[..max_read_length]);
+                return match Pin::new(&mut *file).poll_read(cx, &mut read_buf) {
+                    Poll::Ready(Ok(())) => {
+                        let filled = read_buf.filled();
+                        self.range_remaining -= filled.len() as u64;
+                        if filled.is_empty() {
+                            Poll::Ready(None)
+                        } else {
+                            Poll::Ready(Some(Ok(Bytes::copy_from_slice(filled))))
+                        }
+                    }
+                    Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+                    Poll::Pending => Poll::Pending,
+                }
+            }
+        }
+
     }
 }
 
@@ -30,19 +131,25 @@ impl Stream for FileBytesStream {
         let Self {
             ref mut file,
             ref mut buf,
+            ref mut range_bytes,
         } = *self;
-        let mut read_buf = ReadBuf::uninit(&mut buf[..]);
-        match Pin::new(file).poll_read(cx, &mut read_buf) {
-            Poll::Ready(Ok(())) => {
-                let filled = read_buf.filled();
-                if filled.is_empty() {
-                    Poll::Ready(None)
-                } else {
-                    Poll::Ready(Some(Ok(Bytes::copy_from_slice(filled))))
+
+        if let Some(rb) = range_bytes {
+            rb.handle(file, &mut buf[..], cx)
+        } else {
+            let mut read_buf = ReadBuf::uninit(&mut buf[..]);
+            match Pin::new(file).poll_read(cx, &mut read_buf) {
+                Poll::Ready(Ok(())) => {
+                    let filled = read_buf.filled();
+                    if filled.is_empty() {
+                        Poll::Ready(None)
+                    } else {
+                        Poll::Ready(Some(Ok(Bytes::copy_from_slice(filled))))
+                    }
                 }
+                Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+                Poll::Pending => Poll::Pending,
             }
-            Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
-            Poll::Pending => Poll::Pending,
         }
     }
 }

--- a/src/util/file_response_builder.rs
+++ b/src/util/file_response_builder.rs
@@ -120,7 +120,7 @@ impl FileResponseBuilder {
         let mut res = ResponseBuilder::new();
 
         // Set `Last-Modified` and check `If-Modified-Since`.
-        let modified: Option<DateTime<LocalTz>> = metadata.modified().ok().filter(|v| {
+        let modified = metadata.modified().ok().filter(|v| {
             v.duration_since(UNIX_EPOCH)
                 .ok()
                 .filter(|v| v >= &MIN_VALID_MTIME)

--- a/src/util/file_response_builder.rs
+++ b/src/util/file_response_builder.rs
@@ -207,6 +207,10 @@ impl FileResponseBuilder {
                 if !content_type.is_empty() {
                     body_stream.set_content_type(&content_type);
                 }
+
+                res = res.header(hyper::header::CONTENT_LENGTH,
+                    format!("{}", body_stream.compute_length()));
+
                 return res.status(StatusCode::PARTIAL_CONTENT).body(body_stream.into_body());
             }
         }

--- a/src/util/file_response_builder.rs
+++ b/src/util/file_response_builder.rs
@@ -68,6 +68,7 @@ impl FileResponseBuilder {
     pub fn request_headers(&mut self, headers: &HeaderMap) -> &mut Self {
         self.if_modified_since_header(headers.get(header::IF_MODIFIED_SINCE));
         self.range_header(headers.get(header::RANGE));
+        self.if_range(headers.get(header::IF_RANGE));
         self
     }
 
@@ -99,8 +100,10 @@ impl FileResponseBuilder {
     }
 
     /// Build responses for the given `If-Range` request header value.
-    pub fn if_range(&mut self, value: Option<String>) -> &mut Self {
-        self.if_range = value;
+    pub fn if_range(&mut self, value: Option<&header::HeaderValue>) -> &mut Self {
+        if let Some(s) = value.and_then(|s| s.to_str().ok()) {
+            self.if_range = Some(s.to_string());
+        }
         self
     }
 
@@ -150,6 +153,7 @@ impl FileResponseBuilder {
                 
                 range_cond_ok = *v == modified.to_http_date() || *v == etag;
             }
+
 
             res = res
                 .header(header::LAST_MODIFIED, modified.to_http_date())

--- a/src/util/file_response_builder.rs
+++ b/src/util/file_response_builder.rs
@@ -90,8 +90,17 @@ impl FileResponseBuilder {
     pub fn if_modified_since_header(&mut self, value: Option<&header::HeaderValue>) -> &mut Self {
         self.if_modified_since = value
             .and_then(|v| v.to_str().ok())
-            .and_then(|v| DateTime::parse_from_rfc2822(v).ok())
+        .and_then(|v| DateTime::parse_from_rfc2822(v).ok())
             .map(|v| v.with_timezone(&LocalTz));
+        self
+    }
+
+    /// Build responses for the given `If-Range` request header value.
+    pub fn if_range(&mut self, _value: Option<DateTime<LocalTz>>) -> &mut Self {
+        // self.if_range = value
+        //     .and_then(|v| v.to_str().ok())
+        //     .and_then(|v| DateTime::parse_from_rfc2822(v).ok())
+        //     .map(|v| v.with_timezone(&LocalTz));;
         self
     }
 
@@ -166,7 +175,7 @@ impl FileResponseBuilder {
                                 single_span.start,
                                 single_span.start + single_span.length - 1,
                                 metadata.len()))
-                        .header(header::CONTENT_LENGTH, format!("{}", ranges[0].length));
+                        .header(header::CONTENT_LENGTH, format!("{}", single_span.length));
 
                     let body = FileBytesStreamRange::new(file, single_span).into_body();
                     return res.status(StatusCode::PARTIAL_CONTENT).body(body)

--- a/src/util/file_response_builder.rs
+++ b/src/util/file_response_builder.rs
@@ -35,9 +35,6 @@ pub struct FileResponseBuilder {
     pub if_modified_since: Option<DateTime<LocalTz>>,
     /// The file ranges to read, if any, otherwise we read from the beginning.
     pub range: Option<String>,
-    /// The Content type, this will be added to the response in the main header or
-    /// within part headers as appropriate.
-    pub content_type: Option<String>,
 }
 
 impl FileResponseBuilder {

--- a/tests/static.rs
+++ b/tests/static.rs
@@ -244,3 +244,19 @@ async fn no_headers_for_invalid_mtime() {
     let res = harness.get("/file1.html").await.unwrap();
     assert!(res.headers().get(header::ETAG).is_none());
 }
+
+
+#[tokio::test]
+async fn serves_file_ranges_beginning() {
+    let harness = Harness::new(vec![("file1.html", "this is file1")]);
+
+    let if_modified = Utc::now() + Duration::seconds(3600);
+    let req = Request::builder()
+        .uri("/file1.html")
+        .header(header::RANGE, "bytes -3")
+        .body(())
+        .expect("unable to build request");
+
+    let res = harness.request(req).await.unwrap();
+    assert_eq!(read_body(res).await, "this");
+}

--- a/tests/static.rs
+++ b/tests/static.rs
@@ -3,7 +3,7 @@ use futures_util::stream::StreamExt;
 use http::{header, Request, StatusCode};
 use hyper_staticfile::{DateTimeHttp, Static};
 use std::future::Future;
-use std::io::{Error as IoError, Write};
+use std::io::{Error as IoError, Write, Cursor};
 use std::process::Command;
 use std::{fs, str};
 use tempdir::TempDir;
@@ -245,18 +245,105 @@ async fn no_headers_for_invalid_mtime() {
     assert!(res.headers().get(header::ETAG).is_none());
 }
 
-
 #[tokio::test]
 async fn serves_file_ranges_beginning() {
     let harness = Harness::new(vec![("file1.html", "this is file1")]);
 
-    let if_modified = Utc::now() + Duration::seconds(3600);
     let req = Request::builder()
         .uri("/file1.html")
-        .header(header::RANGE, "bytes -3")
+        .header(header::RANGE, "bytes=0-3")
         .body(())
         .expect("unable to build request");
 
     let res = harness.request(req).await.unwrap();
     assert_eq!(read_body(res).await, "this");
+}
+
+#[tokio::test]
+async fn serves_file_ranges_end() {
+    let harness = Harness::new(vec![("file1.html", "this is file1")]);
+
+    let req = Request::builder()
+        .uri("/file1.html")
+        .header(header::RANGE, "bytes=5-")
+        .body(())
+        .expect("unable to build request");
+
+    let res = harness.request(req).await.unwrap();
+    assert_eq!(read_body(res).await, "is file1");
+}
+
+
+#[tokio::test]
+async fn serves_file_ranges_multi() {
+    let harness = Harness::new(vec![("file1.html", "this is file1")]);
+
+    let req = Request::builder()
+        .uri("/file1.html")
+        .header(header::RANGE, "bytes=0-3, 5-")
+        .body(())
+        .expect("unable to build request");
+
+    let res = harness.request(req).await.unwrap();
+    let content_type = res.headers().get(header::CONTENT_TYPE).unwrap().to_str().unwrap();
+    assert!(content_type.starts_with("multipart/byteranges; boundary="));
+    let boundary = &content_type[31..];
+
+    let mut body_expectation = Cursor::new(Vec::new());
+    write!(&mut body_expectation, "--{}\r\n", boundary).unwrap();
+    write!(&mut body_expectation, "Content-Range: bytes 0-3/13\r\n").unwrap();
+    write!(&mut body_expectation, "Content-Type: text/html\r\n").unwrap();
+    write!(&mut body_expectation, "\r\n").unwrap();
+    write!(&mut body_expectation, "this\r\n").unwrap();
+
+    write!(&mut body_expectation, "--{}\r\n", boundary).unwrap();
+    write!(&mut body_expectation, "Content-Range: bytes 5-12/13\r\n").unwrap();
+    write!(&mut body_expectation, "Content-Type: text/html\r\n").unwrap();
+    write!(&mut body_expectation, "\r\n").unwrap();
+    write!(&mut body_expectation, "is file1\r\n").unwrap();
+    write!(&mut body_expectation, "--{}--\r\n", boundary).unwrap();
+    let body_expectation = String::from_utf8(body_expectation.into_inner()).unwrap();
+
+    assert_eq!(read_body(res).await, body_expectation);
+}
+
+#[tokio::test]
+async fn serves_file_ranges_if_range_negative() {
+    let harness = Harness::new(vec![("file1.html", "this is file1")]);
+
+    let req = Request::builder()
+        .uri("/file1.html")
+        .header(header::RANGE, "bytes=5-")
+        .header(header::IF_RANGE, "Sat, 26 Oct 1985 01:22:00 GMT")
+        .body(())
+        .expect("unable to build request");
+
+    let res = harness.request(req).await.unwrap();
+    // whole thing comes back since If-Range didn't match
+    assert_eq!(read_body(res).await, "this is file1");
+}
+
+
+#[tokio::test]
+async fn serves_file_ranges_if_range_etag_positive() {
+    let harness = Harness::new(vec![("file1.html", "this is file1")]);
+
+    // first request goes out without etag to fetch etag
+    let req = Request::builder()
+        .uri("/file1.html")
+        .body(())
+        .expect("unable to build request");
+
+    let res = harness.request(req).await.unwrap();
+    let etag_value = res.headers().get(header::ETAG).unwrap();
+
+    let req = Request::builder()
+        .uri("/file1.html")
+        .header(header::RANGE, "bytes=5-")
+        .header(header::IF_RANGE, etag_value)
+        .body(())
+        .expect("unable to build request");
+
+    let res = harness.request(req).await.unwrap();
+    assert_eq!(read_body(res).await, "is file1");
 }


### PR DESCRIPTION
TODO:
* ✅ Test `multipart/byteranges` - ~~inspected manually, how do we test this?~~
* ✅ Docstrings
* ✅ [If-Range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Range)
* ✅ No longer using `transfer-encoding: chunked`
  * ~~this is because we aren't sending a Content-Length - the golang http server computes the content length based on the chunk/content-type sizes, newlines and boundaries, so we can also do that.~~
  * ✅ Add a test to ensure content lengths are correct (match body length)
* ✅ Tests!
* ✅ Do we return "416 Requested Range Not Satisfiable" when someone tries to continue a completed file with wget?

Would resolve https://github.com/stephank/hyper-staticfile/issues/9